### PR TITLE
Add three species from grackle mode 2 to GEARRT

### DIFF
--- a/examples/ChemistryTests/MetalAdvectionTestEAGLE/makeIC.py
+++ b/examples/ChemistryTests/MetalAdvectionTestEAGLE/makeIC.py
@@ -61,10 +61,17 @@ def get_element_abundances_metallicity(pos, boxsize):
 
     masks = get_masks(boxsize, pos)
     total_metallicity = np.where(masks["TotalMetallicity"], 0.7, 0.1)
-    element_abundances = [np.where(masks[k], v, 0) for k, v in zip(elements, abundances)]
+    element_abundances = [
+        np.where(masks[k], v, 0) for k, v in zip(elements, abundances)
+    ]
 
     # Finally add H so that H + He + TotalMetallicity = 1
-    return np.stack([1 - element_abundances[0] - total_metallicity, ] + element_abundances, axis=1), total_metallicity
+    return (
+        np.stack(
+            [1 - element_abundances[0] - total_metallicity] + element_abundances, axis=1
+        ),
+        total_metallicity,
+    )
 
 
 if __name__ == "__main__":
@@ -86,7 +93,7 @@ if __name__ == "__main__":
     rho[pos[:, 1] < 0.5 * boxsize[1]] *= 0.5
     masses = rho * np.prod(boxsize) / n_part
     velocities = np.zeros((n_part, 3))
-    velocities[:, :] = 0.5 * math.sqrt(2) * VELOCITY * np.array([1., 1., 0.])
+    velocities[:, :] = 0.5 * math.sqrt(2) * VELOCITY * np.array([1.0, 1.0, 0.0])
     internal_energy = P / (rho * (GAMMA - 1))
 
     # Setup metallicities

--- a/examples/ChemistryTests/MetalAdvectionTestEAGLE/plotAdvectedMetals.py
+++ b/examples/ChemistryTests/MetalAdvectionTestEAGLE/plotAdvectedMetals.py
@@ -37,7 +37,9 @@ def plot_single(ax_mass, ax_fraction, name, title, data, mass_map, kwargs_inner)
     mass_weighted_map = project_gas(data, project=name, **kwargs_inner["projection"])
     ax_mass.imshow(mass_weighted_map.in_cgs().value.T, **kwargs_inner["imshow_mass"])
     ax_mass.set_title(title)
-    ax_fraction.imshow((mass_weighted_map / mass_map).T, **kwargs_inner["imshow_fraction"])
+    ax_fraction.imshow(
+        (mass_weighted_map / mass_map).T, **kwargs_inner["imshow_fraction"]
+    )
     ax_fraction.set_title(title)
     ax_mass.axis("off")
     ax_fraction.axis("off")
@@ -66,7 +68,10 @@ def plot_all(fname, savename):
 
     # Create necessary figures and axes
     fig = plt.figure(layout="constrained", figsize=(16, 8))
-    fig.suptitle(f"Profiles shifted to starting position after t={data.metadata.time:.2f}", fontsize=14)
+    fig.suptitle(
+        f"Profiles shifted to starting position after t={data.metadata.time:.2f}",
+        fontsize=14,
+    )
     fig_ratios, fig_masses = fig.subfigures(2, 1)
     fig_ratios.suptitle("Mass ratio of elements")
     fig_masses.suptitle("Surface density in elements")
@@ -77,11 +82,11 @@ def plot_all(fname, savename):
     projection_kwargs = {
         "region": np.array([0, 2, 0, 1, 0, 1]) * unyt.cm,
         "resolution": 500,
-        "parallel": True
+        "parallel": True,
     }
     # Parameters for imshow
-    norm_ratios = Normalize(0, .95)
-    norm_masses = Normalize(0, .9)
+    norm_ratios = Normalize(0, 0.95)
+    norm_masses = Normalize(0, 0.9)
     imshow_fraction_kwargs = dict(norm=norm_ratios, cmap="rainbow")
     imshow_mass_kwargs = dict(norm=norm_masses, cmap="turbo")
 
@@ -96,23 +101,87 @@ def plot_all(fname, savename):
             projection=projection_kwargs,
             imshow_mass=imshow_mass_kwargs,
             imshow_fraction=imshow_fraction_kwargs,
-        )
+        ),
     )
 
-    plot_single(axes_masses[0][0], axes_ratios[0][0], "total_metal_mass", "All metals", **plotting_kwargs)
-    plot_single(axes_masses[0][1], axes_ratios[0][1], "element_mass_H", "Hydrogen", **plotting_kwargs)
-    plot_single(axes_masses[0][2], axes_ratios[0][2], "element_mass_He", "Helium", **plotting_kwargs)
-    plot_single(axes_masses[0][3], axes_ratios[0][3], "element_mass_C", "Carbon", **plotting_kwargs)
-    plot_single(axes_masses[0][4], axes_ratios[0][4], "element_mass_N", "Nitrogen", **plotting_kwargs)
-    plot_single(axes_masses[1][0], axes_ratios[1][0], "element_mass_O", "Oxygen", **plotting_kwargs)
-    plot_single(axes_masses[1][1], axes_ratios[1][1], "element_mass_Ne", "Neon", **plotting_kwargs)
-    plot_single(axes_masses[1][2], axes_ratios[1][2], "element_mass_Mg", "Magnesium", **plotting_kwargs)
-    plot_single(axes_masses[1][3], axes_ratios[1][3], "element_mass_Si", "Silicon", **plotting_kwargs)
-    plot_single(axes_masses[1][4], axes_ratios[1][4], "element_mass_Fe", "Iron", **plotting_kwargs)
+    plot_single(
+        axes_masses[0][0],
+        axes_ratios[0][0],
+        "total_metal_mass",
+        "All metals",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[0][1],
+        axes_ratios[0][1],
+        "element_mass_H",
+        "Hydrogen",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[0][2],
+        axes_ratios[0][2],
+        "element_mass_He",
+        "Helium",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[0][3],
+        axes_ratios[0][3],
+        "element_mass_C",
+        "Carbon",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[0][4],
+        axes_ratios[0][4],
+        "element_mass_N",
+        "Nitrogen",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[1][0],
+        axes_ratios[1][0],
+        "element_mass_O",
+        "Oxygen",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[1][1],
+        axes_ratios[1][1],
+        "element_mass_Ne",
+        "Neon",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[1][2],
+        axes_ratios[1][2],
+        "element_mass_Mg",
+        "Magnesium",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[1][3],
+        axes_ratios[1][3],
+        "element_mass_Si",
+        "Silicon",
+        **plotting_kwargs,
+    )
+    plot_single(
+        axes_masses[1][4],
+        axes_ratios[1][4],
+        "element_mass_Fe",
+        "Iron",
+        **plotting_kwargs,
+    )
 
     # Add Colorbars
-    cb_masses = fig_masses.colorbar(ScalarMappable(**imshow_mass_kwargs), shrink=0.75, pad=0.01, ax=axes_masses)
-    cb_ratios = fig_ratios.colorbar(ScalarMappable(**imshow_fraction_kwargs), shrink=0.75, pad=0.01, ax=axes_ratios)
+    cb_masses = fig_masses.colorbar(
+        ScalarMappable(**imshow_mass_kwargs), shrink=0.75, pad=0.01, ax=axes_masses
+    )
+    cb_ratios = fig_ratios.colorbar(
+        ScalarMappable(**imshow_fraction_kwargs), shrink=0.75, pad=0.01, ax=axes_ratios
+    )
     cb_masses.ax.set_ylabel("Surface density (g/cm^2)", rotation=270, labelpad=15)
     cb_ratios.ax.set_ylabel("Mass ratio", rotation=270, labelpad=15)
 

--- a/examples/ChemistryTests/MetalAdvectionTestEAGLE/runSanityChecksAdvectedMetals.py
+++ b/examples/ChemistryTests/MetalAdvectionTestEAGLE/runSanityChecksAdvectedMetals.py
@@ -70,7 +70,7 @@ def element_mass(data, element_name):
 def test_h_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "hydrogen")),
-        np.sum(element_mass(data_end, "hydrogen"))
+        np.sum(element_mass(data_end, "hydrogen")),
     )
 
 
@@ -78,7 +78,7 @@ def test_h_mass_conservation(data_start, data_end):
 def test_he_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "helium")),
-        np.sum(element_mass(data_end, "helium"))
+        np.sum(element_mass(data_end, "helium")),
     )
 
 
@@ -86,7 +86,7 @@ def test_he_mass_conservation(data_start, data_end):
 def test_c_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "carbon")),
-        np.sum(element_mass(data_end, "carbon"))
+        np.sum(element_mass(data_end, "carbon")),
     )
 
 
@@ -94,7 +94,7 @@ def test_c_mass_conservation(data_start, data_end):
 def test_n_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "nitrogen")),
-        np.sum(element_mass(data_end, "nitrogen"))
+        np.sum(element_mass(data_end, "nitrogen")),
     )
 
 
@@ -102,15 +102,14 @@ def test_n_mass_conservation(data_start, data_end):
 def test_o_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "oxygen")),
-        np.sum(element_mass(data_end, "oxygen"))
+        np.sum(element_mass(data_end, "oxygen")),
     )
 
 
 @test("neon mass conservation")
 def test_ne_mass_conservation(data_start, data_end):
     assert approx_equal(
-        np.sum(element_mass(data_start, "neon")),
-        np.sum(element_mass(data_end, "neon"))
+        np.sum(element_mass(data_start, "neon")), np.sum(element_mass(data_end, "neon"))
     )
 
 
@@ -118,7 +117,7 @@ def test_ne_mass_conservation(data_start, data_end):
 def test_mg_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "magnesium")),
-        np.sum(element_mass(data_end, "magnesium"))
+        np.sum(element_mass(data_end, "magnesium")),
     )
 
 
@@ -126,15 +125,14 @@ def test_mg_mass_conservation(data_start, data_end):
 def test_si_mass_conservation(data_start, data_end):
     assert approx_equal(
         np.sum(element_mass(data_start, "silicon")),
-        np.sum(element_mass(data_end, "silicon"))
+        np.sum(element_mass(data_end, "silicon")),
     )
 
 
 @test("iron mass conservation")
 def test_fe_mass_conservation(data_start, data_end):
     assert approx_equal(
-        np.sum(element_mass(data_start, "iron")),
-        np.sum(element_mass(data_end, "iron"))
+        np.sum(element_mass(data_start, "iron")), np.sum(element_mass(data_end, "iron"))
     )
 
 

--- a/examples/ChemistryTests/MetalAdvectionTestGEAR/makeIC.py
+++ b/examples/ChemistryTests/MetalAdvectionTestGEAR/makeIC.py
@@ -60,7 +60,9 @@ def get_abundance(element_idx):
 def get_element_abundances_metallicity(pos, boxsize):
     element_abundances = []
     for i in range(ELEMENT_COUNT):
-        element_abundances.append(np.where(get_mask(boxsize, pos, i), get_abundance(i), 0))
+        element_abundances.append(
+            np.where(get_mask(boxsize, pos, i), get_abundance(i), 0)
+        )
 
     return np.stack(element_abundances, axis=1)
 
@@ -84,7 +86,7 @@ if __name__ == "__main__":
     rho[pos[:, 1] < 0.5 * boxsize[1]] *= 0.5
     masses = rho * np.prod(boxsize) / n_part
     velocities = np.zeros((n_part, 3))
-    velocities[:, :] = 0.5 * math.sqrt(2) * VELOCITY * np.array([1., 1., 0.])
+    velocities[:, :] = 0.5 * math.sqrt(2) * VELOCITY * np.array([1.0, 1.0, 0.0])
     internal_energy = P / (rho * (GAMMA - 1))
 
     # Setup metallicities
@@ -129,6 +131,10 @@ if __name__ == "__main__":
     file.close()
 
     if ELEMENT_COUNT == 2:
-        print(f"Make sure swift was compiled with `--with-chemistry=GEAR_2` or `--with-chemistry=AGORA`")
+        print(
+            f"Make sure swift was compiled with `--with-chemistry=GEAR_2` or `--with-chemistry=AGORA`"
+        )
     else:
-        print(f"Make sure swift was compiled with `--with-chemistry=GEAR_{ELEMENT_COUNT}`")
+        print(
+            f"Make sure swift was compiled with `--with-chemistry=GEAR_{ELEMENT_COUNT}`"
+        )

--- a/examples/ChemistryTests/MetalAdvectionTestGEAR/plotAdvectedMetals.py
+++ b/examples/ChemistryTests/MetalAdvectionTestGEAR/plotAdvectedMetals.py
@@ -37,7 +37,9 @@ def plot_single(ax_mass, ax_fraction, name, title, data, mass_map, kwargs_inner)
     mass_weighted_map = project_gas(data, project=name, **kwargs_inner["projection"])
     ax_mass.imshow(mass_weighted_map.in_cgs().value.T, **kwargs_inner["imshow_mass"])
     ax_mass.set_title(title)
-    ax_fraction.imshow((mass_weighted_map / mass_map).value.T, **kwargs_inner["imshow_fraction"])
+    ax_fraction.imshow(
+        (mass_weighted_map / mass_map).value.T, **kwargs_inner["imshow_fraction"]
+    )
     ax_fraction.set_title(title)
     ax_mass.axis("off")
     ax_fraction.axis("off")
@@ -56,13 +58,21 @@ def plot_all(fname, savename):
     columns = getattr(element_mass_fractions, "named_columns", None)
     for i in range(ELEMENT_COUNT):
         if columns is None:
-            data.gas.__setattr__(f"element_mass_sp{i}", element_mass_fractions[:, i] * masses)
+            data.gas.__setattr__(
+                f"element_mass_sp{i}", element_mass_fractions[:, i] * masses
+            )
         else:
-            data.gas.__setattr__(f"element_mass_sp{i}", getattr(element_mass_fractions, columns[i]) * masses)
+            data.gas.__setattr__(
+                f"element_mass_sp{i}",
+                getattr(element_mass_fractions, columns[i]) * masses,
+            )
 
     # Create necessary figures and axes
     fig = plt.figure(layout="constrained", figsize=(8, 2 * ELEMENT_COUNT + 1))
-    fig.suptitle(f"Profiles shifted to starting position after t={data.metadata.time:.2f}", fontsize=14)
+    fig.suptitle(
+        f"Profiles shifted to starting position after t={data.metadata.time:.2f}",
+        fontsize=14,
+    )
     fig_ratios, fig_masses = fig.subfigures(1, 2)
     fig_ratios.suptitle("Mass ratio of elements")
     fig_masses.suptitle("Surface density in elements")
@@ -73,16 +83,16 @@ def plot_all(fname, savename):
     projection_kwargs = {
         "region": np.array([0, 2, 0, 1, 0, 1]) * unyt.cm,
         "resolution": 500,
-        "parallel": True
+        "parallel": True,
     }
     # Parameters for imshow
     if ELEMENT_COUNT > 5:
         thresh = 10 ** math.floor(math.log10(0.5 ** (ELEMENT_COUNT - 2)))
-        norm_ratios = SymLogNorm(vmin=0, vmax=.21, linthresh=thresh, base=10)
-        norm_masses = SymLogNorm(vmin=0, vmax=.25, linthresh=thresh, base=10)
+        norm_ratios = SymLogNorm(vmin=0, vmax=0.21, linthresh=thresh, base=10)
+        norm_masses = SymLogNorm(vmin=0, vmax=0.25, linthresh=thresh, base=10)
     else:
-        norm_ratios = Normalize(vmin=0, vmax=.21)
-        norm_masses = Normalize(vmin=0, vmax=.25)
+        norm_ratios = Normalize(vmin=0, vmax=0.21)
+        norm_masses = Normalize(vmin=0, vmax=0.25)
     imshow_fraction_kwargs = dict(norm=norm_ratios, cmap="rainbow")
     imshow_mass_kwargs = dict(norm=norm_masses, cmap="turbo")
 
@@ -97,19 +107,35 @@ def plot_all(fname, savename):
             projection=projection_kwargs,
             imshow_mass=imshow_mass_kwargs,
             imshow_fraction=imshow_fraction_kwargs,
-        )
+        ),
     )
 
     if columns is None:
         columns = [f"Species {i + 1}" for i in range(ELEMENT_COUNT)]
     for i in range(ELEMENT_COUNT):
-        plot_single(axes_masses[i], axes_ratios[i], f"element_mass_sp{i}", columns[i], **plotting_kwargs)
+        plot_single(
+            axes_masses[i],
+            axes_ratios[i],
+            f"element_mass_sp{i}",
+            columns[i],
+            **plotting_kwargs,
+        )
 
     # Add Colorbars
-    cb_masses = fig_masses.colorbar(ScalarMappable(**imshow_mass_kwargs), orientation="horizontal", shrink=0.75,
-                                    pad=0.01, ax=axes_masses)
-    cb_ratios = fig_ratios.colorbar(ScalarMappable(**imshow_fraction_kwargs), orientation="horizontal", shrink=0.75,
-                                    pad=0.01, ax=axes_ratios)
+    cb_masses = fig_masses.colorbar(
+        ScalarMappable(**imshow_mass_kwargs),
+        orientation="horizontal",
+        shrink=0.75,
+        pad=0.01,
+        ax=axes_masses,
+    )
+    cb_ratios = fig_ratios.colorbar(
+        ScalarMappable(**imshow_fraction_kwargs),
+        orientation="horizontal",
+        shrink=0.75,
+        pad=0.01,
+        ax=axes_ratios,
+    )
     cb_masses.ax.set_xlabel("Surface density (g/cm^2)")
     cb_ratios.ax.set_xlabel("Mass ratio")
 

--- a/examples/ChemistryTests/MetalAdvectionTestGEAR/runSanityChecksAdvectedMetals.py
+++ b/examples/ChemistryTests/MetalAdvectionTestGEAR/runSanityChecksAdvectedMetals.py
@@ -25,6 +25,7 @@ import swiftsimio
 
 from makeIC import ELEMENT_COUNT
 
+
 def test(name):
     def test_decorator(test_func):
         def test_runner(*args, **kwargs):
@@ -50,7 +51,10 @@ def test_total_metal_mass_conservation(data_start, data_end):
     def metal_mass(data):
         columns = getattr(data.gas.metal_mass_fractions, "named_columns", None)
         if columns is not None:
-            return sum(data.gas.masses * getattr(data.gas.metal_mass_fractions, c) for c in columns)
+            return sum(
+                data.gas.masses * getattr(data.gas.metal_mass_fractions, c)
+                for c in columns
+            )
         else:
             return data.gas.masses.reshape(-1, 1) * data.gas.metal_mass_fractions
 
@@ -60,7 +64,9 @@ def test_total_metal_mass_conservation(data_start, data_end):
 def element_mass(data, element_idx):
     columns = getattr(data.gas.metal_mass_fractions, "named_columns", None)
     if columns is not None:
-        return data.gas.masses * getattr(data.gas.metal_mass_fractions, columns[element_idx])
+        return data.gas.masses * getattr(
+            data.gas.metal_mass_fractions, columns[element_idx]
+        )
     else:
         return data.gas.masses * data.gas.metal_mass_fractions[:, element_idx]
 
@@ -69,8 +75,7 @@ def element_mass(data, element_idx):
 def test_element_wise_mass_conservation(data_start, data_end):
     for i in range(ELEMENT_COUNT):
         assert approx_equal(
-            np.sum(element_mass(data_start, i)),
-            np.sum(element_mass(data_end, i))
+            np.sum(element_mass(data_start, i)), np.sum(element_mass(data_end, i))
         )
 
 

--- a/src/rt/GEAR/rt_grackle_utils.h
+++ b/src/rt/GEAR/rt_grackle_utils.h
@@ -26,6 +26,7 @@
 #include "hydro.h"
 
 #include <grackle.h>
+#include "rt_species.h"
 
 /* need to rework (and check) code if changed */
 #define FIELD_SIZE 1
@@ -225,19 +226,19 @@ rt_get_grackle_particle_fields(grackle_field_data *grackle_fields,
     grackle_fields->internal_energy[i] = internal_energy;
     
     #if GEARRT_GRACKLE_MODE >= 1
-      grackle_fields->HI_density[i] = species_densities[0];
-      grackle_fields->HII_density[i] = species_densities[1];
-      grackle_fields->HeI_density[i] = species_densities[2];
-      grackle_fields->HeII_density[i] = species_densities[3];
-      grackle_fields->HeIII_density[i] = species_densities[4];
+      grackle_fields->HI_density[i] = species_densities[rt_species_HI];
+      grackle_fields->HII_density[i] = species_densities[rt_species_HII];
+      grackle_fields->HeI_density[i] = species_densities[rt_species_HeI];
+      grackle_fields->HeII_density[i] = species_densities[rt_species_HeII];
+      grackle_fields->HeIII_density[i] = species_densities[rt_species_HeIII];
       /* e_density = electron density*mh/me = n_e * m_h */
-      grackle_fields->e_density[i] = species_densities[5];
+      grackle_fields->e_density[i] = species_densities[rt_species_e];
     #endif
 
     #if GEARRT_GRACKLE_MODE >= 2
-      grackle_fields->HM_density[i] = species_densities[6]; 
-      grackle_fields->H2I_density[i] = species_densities[7];
-      grackle_fields->H2II_density[i] = species_densities[8];
+      grackle_fields->HM_density[i] = species_densities[rt_species_HM]; 
+      grackle_fields->H2I_density[i] = species_densities[rt_species_H2I];
+      grackle_fields->H2II_density[i] = species_densities[rt_species_H2II];
     #endif
 
     /* grackle_fields->DI_density[i] = species_densities[9]; */

--- a/src/rt/GEAR/rt_io.h
+++ b/src/rt/GEAR/rt_io.h
@@ -55,19 +55,19 @@ INLINE static int rt_read_particles(const struct part* parts,
 
   list[count++] = io_make_input_field("MassFractionHI", FLOAT, 1, OPTIONAL,
                                       UNIT_CONV_NO_UNITS, parts,
-                                      rt_data.tchem.mass_fraction_HI);
+                                      rt_data.tchem.mass_fraction[rt_species_HI]);
   list[count++] = io_make_input_field("MassFractionHII", FLOAT, 1, OPTIONAL,
                                       UNIT_CONV_NO_UNITS, parts,
-                                      rt_data.tchem.mass_fraction_HII);
+                                      rt_data.tchem.mass_fraction[rt_species_HII]);
   list[count++] = io_make_input_field("MassFractionHeI", FLOAT, 1, OPTIONAL,
                                       UNIT_CONV_NO_UNITS, parts,
-                                      rt_data.tchem.mass_fraction_HeI);
+                                      rt_data.tchem.mass_fraction[rt_species_HeI]);
   list[count++] = io_make_input_field("MassFractionHeII", FLOAT, 1, OPTIONAL,
                                       UNIT_CONV_NO_UNITS, parts,
-                                      rt_data.tchem.mass_fraction_HeII);
+                                      rt_data.tchem.mass_fraction[rt_species_HeII]);
   list[count++] = io_make_input_field("MassFractionHeIII", FLOAT, 1, OPTIONAL,
                                       UNIT_CONV_NO_UNITS, parts,
-                                      rt_data.tchem.mass_fraction_HeIII);
+                                      rt_data.tchem.mass_fraction[rt_species_HeIII]);
 
   return count;
 }
@@ -140,11 +140,11 @@ INLINE static void rt_convert_mass_fractions(const struct engine* engine,
                                              const struct xpart* xpart,
                                              float* ret) {
 
-  ret[0] = part->rt_data.tchem.mass_fraction_HI;
-  ret[1] = part->rt_data.tchem.mass_fraction_HII;
-  ret[2] = part->rt_data.tchem.mass_fraction_HeI;
-  ret[3] = part->rt_data.tchem.mass_fraction_HeII;
-  ret[4] = part->rt_data.tchem.mass_fraction_HeIII;
+  ret[0] = part->rt_data.tchem.mass_fraction[rt_species_HI];
+  ret[1] = part->rt_data.tchem.mass_fraction[rt_species_HII];
+  ret[2] = part->rt_data.tchem.mass_fraction[rt_species_HeI];
+  ret[3] = part->rt_data.tchem.mass_fraction[rt_species_HeII];
+  ret[4] = part->rt_data.tchem.mass_fraction[rt_species_HeIII];
 }
 
 /**

--- a/src/rt/GEAR/rt_species.h
+++ b/src/rt/GEAR/rt_species.h
@@ -32,6 +32,29 @@ enum rt_ionizing_species {
 };
 
 /**
+ * @file src/rt/GEAR/rt_species.h
+ * @brief header file concerning species.
+ **/
+
+enum rt_species {
+#if GEARRT_GRACKLE_MODE >= 1
+  rt_species_HI = 0,
+  rt_species_HII,
+  rt_species_HeI,
+  rt_species_HeII,
+  rt_species_HeIII,
+  rt_species_e,
+#endif
+
+#if GEARRT_GRACKLE_MODE >= 2
+  rt_species_HM,
+  rt_species_H2I,
+  rt_species_H2II,
+#endif
+  rt_species_count
+};
+
+/**
  * Get the ionizing energy in erg for all ionizing species.
  *
  * @param E_ion (return) the ionizing energies.

--- a/src/rt/GEAR/rt_struct.h
+++ b/src/rt/GEAR/rt_struct.h
@@ -64,6 +64,7 @@ struct rt_part_data {
   /* } limiter[RT_NGROUPS]; */
 
   /* Data for thermochemistry */
+#if GEARRT_GRACKLE_MODE == 1
   struct {
     float mass_fraction_HI;         /* mass fraction taken by HI */
     float mass_fraction_HII;        /* mass fraction taken by HII */
@@ -72,6 +73,19 @@ struct rt_part_data {
     float mass_fraction_HeIII;      /* mass fraction taken by HeIII */
     float number_density_electrons; /* number density of electrons */
   } tchem;
+#elif GEARRT_GRACKLE_MODE == 2
+  struct {
+    float mass_fraction_HI;         /* mass fraction taken by HI */
+    float mass_fraction_HII;        /* mass fraction taken by HII */
+    float mass_fraction_HeI;        /* mass fraction taken by HeI */
+    float mass_fraction_HeII;       /* mass fraction taken by HeII */
+    float mass_fraction_HeIII;      /* mass fraction taken by HeIII */
+    float number_density_electrons; /* number density of electrons */
+    float mass_fraction_HM;         /* mass fraction taken by HM */
+    float mass_fraction_H2I;         /* mass fraction taken by H2I */
+    float mass_fraction_H2II;         /* mass fraction taken by H2II */
+  } tchem;
+#endif
 
 #ifdef GIZMO_MFV_SPH
   /* Keep track of the actual mass fluxes of the gas species */

--- a/src/rt/GEAR/rt_struct.h
+++ b/src/rt/GEAR/rt_struct.h
@@ -66,31 +66,9 @@ struct rt_part_data {
   /* } limiter[RT_NGROUPS]; */
 
   /* Data for thermochemistry */
-//#if GEARRT_GRACKLE_MODE == 1
-  //struct {
-    //float mass_fraction_HI;         
-    //float mass_fraction_HII;        
-    //float mass_fraction_HeI;        
-    //float mass_fraction_HeII;       
-    //float mass_fraction_HeIII;      
-    //float number_density_electrons; 
-  //} tchem;
-//#elif GEARRT_GRACKLE_MODE == 2
-  //struct {
-    //float mass_fraction_HI;         
-    //float mass_fraction_HII;        
-    //float mass_fraction_HeI;        
-    //float mass_fraction_HeII;       
-    //float mass_fraction_HeIII;      
-    //float number_density_electrons; 
-    //float mass_fraction_HM;         
-    //float mass_fraction_H2I;       
-    //float mass_fraction_H2II;         
-  //} tchem;
-//#endif
-struct {
-   float mass_fraction[rt_species_count];
- } tchem;
+  struct {
+    float mass_fraction[rt_species_count];
+  } tchem;
 
 #ifdef GIZMO_MFV_SPH
   /* Keep track of the actual mass fluxes of the gas species */

--- a/src/rt/GEAR/rt_struct.h
+++ b/src/rt/GEAR/rt_struct.h
@@ -19,6 +19,8 @@
 #ifndef SWIFT_RT_STRUCT_GEAR_H
 #define SWIFT_RT_STRUCT_GEAR_H
 
+#include "rt_species.h"
+
 /**
  * @file src/rt/GEAR/rt_struct.h
  * @brief Main header file for the GEAR M1 Closure radiative transfer struct.
@@ -64,28 +66,31 @@ struct rt_part_data {
   /* } limiter[RT_NGROUPS]; */
 
   /* Data for thermochemistry */
-#if GEARRT_GRACKLE_MODE == 1
-  struct {
-    float mass_fraction_HI;         /* mass fraction taken by HI */
-    float mass_fraction_HII;        /* mass fraction taken by HII */
-    float mass_fraction_HeI;        /* mass fraction taken by HeI */
-    float mass_fraction_HeII;       /* mass fraction taken by HeII */
-    float mass_fraction_HeIII;      /* mass fraction taken by HeIII */
-    float number_density_electrons; /* number density of electrons */
-  } tchem;
-#elif GEARRT_GRACKLE_MODE == 2
-  struct {
-    float mass_fraction_HI;         /* mass fraction taken by HI */
-    float mass_fraction_HII;        /* mass fraction taken by HII */
-    float mass_fraction_HeI;        /* mass fraction taken by HeI */
-    float mass_fraction_HeII;       /* mass fraction taken by HeII */
-    float mass_fraction_HeIII;      /* mass fraction taken by HeIII */
-    float number_density_electrons; /* number density of electrons */
-    float mass_fraction_HM;         /* mass fraction taken by HM */
-    float mass_fraction_H2I;         /* mass fraction taken by H2I */
-    float mass_fraction_H2II;         /* mass fraction taken by H2II */
-  } tchem;
-#endif
+//#if GEARRT_GRACKLE_MODE == 1
+  //struct {
+    //float mass_fraction_HI;         
+    //float mass_fraction_HII;        
+    //float mass_fraction_HeI;        
+    //float mass_fraction_HeII;       
+    //float mass_fraction_HeIII;      
+    //float number_density_electrons; 
+  //} tchem;
+//#elif GEARRT_GRACKLE_MODE == 2
+  //struct {
+    //float mass_fraction_HI;         
+    //float mass_fraction_HII;        
+    //float mass_fraction_HeI;        
+    //float mass_fraction_HeII;       
+    //float mass_fraction_HeIII;      
+    //float number_density_electrons; 
+    //float mass_fraction_HM;         
+    //float mass_fraction_H2I;       
+    //float mass_fraction_H2II;         
+  //} tchem;
+//#endif
+struct {
+   float mass_fraction[rt_species_count];
+ } tchem;
 
 #ifdef GIZMO_MFV_SPH
   /* Keep track of the actual mass fluxes of the gas species */

--- a/src/rt/GEAR/rt_thermochemistry.h
+++ b/src/rt/GEAR/rt_thermochemistry.h
@@ -53,26 +53,26 @@ __attribute__((always_inline)) INLINE static void rt_tchem_first_init_part(
       rt_ion_equil_get_mass_fractions(&XHI, &XHII, &XHeI, &XHeII, &XHeIII, p,
                                     rt_props, hydro_props, phys_const, us,
                                     cosmo);
-      p->rt_data.tchem.mass_fraction_HI = XHI;
-      p->rt_data.tchem.mass_fraction_HII = XHII;
-      p->rt_data.tchem.mass_fraction_HeI = XHeI;
-      p->rt_data.tchem.mass_fraction_HeII = XHeII;
-      p->rt_data.tchem.mass_fraction_HeIII = XHeIII;
+      p->rt_data.tchem.mass_fraction[rt_species_HI] = XHI;
+      p->rt_data.tchem.mass_fraction[rt_species_HII] = XHII;
+      p->rt_data.tchem.mass_fraction[rt_species_HeI] = XHeI;
+      p->rt_data.tchem.mass_fraction[rt_species_HeII] = XHeII;
+      p->rt_data.tchem.mass_fraction[rt_species_HeIII] = XHeIII;
     } else if (rt_props->set_initial_ionization_mass_fractions) {
-      p->rt_data.tchem.mass_fraction_HI = rt_props->mass_fraction_HI_init;
-      p->rt_data.tchem.mass_fraction_HII = rt_props->mass_fraction_HII_init;
-      p->rt_data.tchem.mass_fraction_HeI = rt_props->mass_fraction_HeI_init;
-      p->rt_data.tchem.mass_fraction_HeII = rt_props->mass_fraction_HeII_init;
-      p->rt_data.tchem.mass_fraction_HeIII = rt_props->mass_fraction_HeIII_init;
+      p->rt_data.tchem.mass_fraction[rt_species_HI] = rt_props->mass_fraction_HI_init;
+      p->rt_data.tchem.mass_fraction[rt_species_HII] = rt_props->mass_fraction_HII_init;
+      p->rt_data.tchem.mass_fraction[rt_species_HeI] = rt_props->mass_fraction_HeI_init;
+      p->rt_data.tchem.mass_fraction[rt_species_HeII] = rt_props->mass_fraction_HeII_init;
+      p->rt_data.tchem.mass_fraction[rt_species_HeIII] = rt_props->mass_fraction_HeIII_init;
     }
   #endif
   
   /* for primordial_chemistry >= 2 */
   #if GEARRT_GRACKLE_MODE >= 2
       const float zero = 0.f;
-      p->rt_data.tchem.mass_fraction_HM = zero;
-      p->rt_data.tchem.mass_fraction_H2I = zero;
-      p->rt_data.tchem.mass_fraction_H2II = zero;
+      p->rt_data.tchem.mass_fraction[rt_species_HM] = zero;
+      p->rt_data.tchem.mass_fraction[rt_species_H2I] = zero;
+      p->rt_data.tchem.mass_fraction[rt_species_H2II] = zero;
   #endif
 
   /* pretend you have nonzero density so the check doesn't reset the mass
@@ -87,13 +87,13 @@ __attribute__((always_inline)) INLINE static void rt_tchem_first_init_part(
    * passed down to grackle internally, so it is error-prone if left
    * unchecked. */
   const float mH =
-      p->rt_data.tchem.mass_fraction_HI + p->rt_data.tchem.mass_fraction_HII;
+      p->rt_data.tchem.mass_fraction[rt_species_HI] + p->rt_data.tchem.mass_fraction[rt_species_HII];
   if (fabsf(mH - rt_props->hydrogen_mass_fraction) > 1e-4)
     error("Got wrong Hydrogen mass fraction: Got =%.6f provided in yml =%.6f",
           mH, rt_props->hydrogen_mass_fraction);
-  const float mHe = p->rt_data.tchem.mass_fraction_HeI +
-                    p->rt_data.tchem.mass_fraction_HeII +
-                    p->rt_data.tchem.mass_fraction_HeIII;
+  const float mHe = p->rt_data.tchem.mass_fraction[rt_species_HeI] +
+                    p->rt_data.tchem.mass_fraction[rt_species_HeII] +
+                    p->rt_data.tchem.mass_fraction[rt_species_HeIII];
   if (fabsf(mHe - rt_props->helium_mass_fraction) > 1e-4)
     error("Got wrong Helium mass fraction: Got =%.6f provided in yml =%.6f",
           mHe, rt_props->helium_mass_fraction);
@@ -200,24 +200,24 @@ INLINE static void rt_do_thermochemistry(
   const gr_float one_over_rho = 1. / density;
   /* for primordial_chemistry >= 1 */
 #if GEARRT_GRACKLE_MODE >= 1
-  p->rt_data.tchem.mass_fraction_HI =
+  p->rt_data.tchem.mass_fraction[rt_species_HI] =
       particle_grackle_data.HI_density[0] * one_over_rho;
-  p->rt_data.tchem.mass_fraction_HII =
+  p->rt_data.tchem.mass_fraction[rt_species_HII] =
       particle_grackle_data.HII_density[0] * one_over_rho;
-  p->rt_data.tchem.mass_fraction_HeI =
+  p->rt_data.tchem.mass_fraction[rt_species_HeI] =
       particle_grackle_data.HeI_density[0] * one_over_rho;
-  p->rt_data.tchem.mass_fraction_HeII =
+  p->rt_data.tchem.mass_fraction[rt_species_HeII] =
       particle_grackle_data.HeII_density[0] * one_over_rho;
-  p->rt_data.tchem.mass_fraction_HeIII =
+  p->rt_data.tchem.mass_fraction[rt_species_HeIII] =
       particle_grackle_data.HeIII_density[0] * one_over_rho;
 #endif
   /* for primordial_chemistry >= 2 */
 #if GEARRT_GRACKLE_MODE >= 2
-  p->rt_data.tchem.mass_fraction_HM =
+  p->rt_data.tchem.mass_fraction[rt_species_HM] =
       particle_grackle_data.HM_density[0] * one_over_rho;
-  p->rt_data.tchem.mass_fraction_H2I =
+  p->rt_data.tchem.mass_fraction[rt_species_H2I] =
       particle_grackle_data.H2I_density[0] * one_over_rho;
-  p->rt_data.tchem.mass_fraction_H2II =
+  p->rt_data.tchem.mass_fraction[rt_species_H2II] =
       particle_grackle_data.H2II_density[0] * one_over_rho;
 #endif
 

--- a/src/rt/GEAR/rt_thermochemistry_utils.h
+++ b/src/rt/GEAR/rt_thermochemistry_utils.h
@@ -112,51 +112,33 @@ __attribute__((always_inline)) INLINE static float rt_tchem_internal_energy_dT(
 __attribute__((always_inline)) INLINE static void
 rt_tchem_get_species_densities(const struct part* restrict p, gr_float rho,
                                gr_float species_densities[RT_N_SPECIES]) {
-  /* for primordial_chemistry >= 1 */
-  //#if GEARRT_GRACKLE_MODE >= 1
-    //species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
-    //species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
-    //species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
-    //species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
-    //species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
 
     /* nHII = rho_HII / m_p
      * nHeII = rho_HeII / 4 m_p
      * nHeIII = rho_HeIII / 4 m_p
      * ne = nHII + nHeII + 2 * nHeIII
      * But: it is grackle convention to use rho_e = n_e * m_p */
-    //const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
-     //                    0.5 * species_densities[4];
-    //species_densities[5] = rho_e;
-  //#endif
-
-  /* for primordial_chemistry >= 2 */
-  //#if GEARRT_GRACKLE_MODE >= 2
-    //species_densities[6] = p->rt_data.tchem.mass_fraction_HM * rho;
-    //species_densities[7] = p->rt_data.tchem.mass_fraction_H2I * rho;
-    //species_densities[8] = p->rt_data.tchem.mass_fraction_H2II * rho;
-   
-    //const gr_float rho_e2 = species_densities[1] + 0.25 * species_densities[3] +
-    //                     0.5 * species_densities[4] - species_densities[6] + 0.5 * species_densities[8];
-    //species_densities[5] = rho_e2;
-  //#endif
+ 
   for (enum rt_species species = 0; species < rt_species_count; species++){
 	if (species != 5)
 	{
 		species_densities[species] = p->rt_data.tchem.mass_fraction[species];
 	}
   }
-
-  #if GEARRT_GRACKLE_MODE >= 1
+  
+  /* for primordial_chemistry >= 1 */
+  #if GEARRT_GRACKLE_MODE == 1
   const gr_float rho_e = species_densities[rt_species_HII] + 0.25 * species_densities[rt_species_HeII] +
                          0.5 * species_densities[rt_species_HeIII];
   species_densities[rt_species_e] = rho_e;
   #endif
-	
-  #if GEARRT_GRACKLE_MODE >= 2
-  const gr_float rho_e2 = species_densities[rt_species_HII] + 0.25 * species_densities[rt_species_HeII] +
+
+  /* for primordial_chemistry >= 2 */  
+  #if GEARRT_GRACKLE_MODE == 2
+  const gr_float rho_e = species_densities[rt_species_HII] + 0.25 * species_densities[rt_species_HeII] +
                          0.5 * species_densities[rt_species_HeIII] - species_densities[rt_species_HM] + 0.5 * species_densities[rt_species_H2II];
-  species_densities[rt_species_e] = rho_e2;
+
+  species_densities[rt_species_e] = rho_e;
   #endif
 
 }

--- a/src/rt/GEAR/rt_thermochemistry_utils.h
+++ b/src/rt/GEAR/rt_thermochemistry_utils.h
@@ -111,22 +111,35 @@ __attribute__((always_inline)) INLINE static float rt_tchem_internal_energy_dT(
  **/
 __attribute__((always_inline)) INLINE static void
 rt_tchem_get_species_densities(const struct part* restrict p, gr_float rho,
-                               gr_float species_densities[6]) {
+                               gr_float species_densities[RT_N_SPECIES]) {
+  /* for primordial_chemistry >= 1 */
+  #if GEARRT_GRACKLE_MODE >= 1
+    species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
+    species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
+    species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
+    species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
+    species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
 
-  species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
-  species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
-  species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
-  species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
-  species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
-
-  /* nHII = rho_HII / m_p
-   * nHeII = rho_HeII / 4 m_p
-   * nHeIII = rho_HeIII / 4 m_p
-   * ne = nHII + nHeII + 2 * nHeIII
-   * But: it is grackle convention to use rho_e = n_e * m_p */
-  const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
+    /* nHII = rho_HII / m_p
+     * nHeII = rho_HeII / 4 m_p
+     * nHeIII = rho_HeIII / 4 m_p
+     * ne = nHII + nHeII + 2 * nHeIII
+     * But: it is grackle convention to use rho_e = n_e * m_p */
+    const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
                          0.5 * species_densities[4];
-  species_densities[5] = rho_e;
+    species_densities[5] = rho_e;
+  #endif
+
+  /* for primordial_chemistry >= 2 */
+  #if GEARRT_GRACKLE_MODE >= 2
+    species_densities[6] = p->rt_data.tchem.mass_fraction_HM * rho;
+    species_densities[7] = p->rt_data.tchem.mass_fraction_H2I * rho;
+    species_densities[8] = p->rt_data.tchem.mass_fraction_H2II * rho;
+
+    const gr_float rho_e2 = species_densities[1] + 0.25 * species_densities[3] +
+                         0.5 * species_densities[4] - species_densities[6] + 0.5 * species_densities[8];
+    species_densities[5] = rho_e2;
+  #endif
 }
 
 /**

--- a/src/rt/GEAR/rt_thermochemistry_utils.h
+++ b/src/rt/GEAR/rt_thermochemistry_utils.h
@@ -113,33 +113,52 @@ __attribute__((always_inline)) INLINE static void
 rt_tchem_get_species_densities(const struct part* restrict p, gr_float rho,
                                gr_float species_densities[RT_N_SPECIES]) {
   /* for primordial_chemistry >= 1 */
-  #if GEARRT_GRACKLE_MODE >= 1
-    species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
-    species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
-    species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
-    species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
-    species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
+  //#if GEARRT_GRACKLE_MODE >= 1
+    //species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
+    //species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
+    //species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
+    //species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
+    //species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
 
     /* nHII = rho_HII / m_p
      * nHeII = rho_HeII / 4 m_p
      * nHeIII = rho_HeIII / 4 m_p
      * ne = nHII + nHeII + 2 * nHeIII
      * But: it is grackle convention to use rho_e = n_e * m_p */
-    const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
-                         0.5 * species_densities[4];
-    species_densities[5] = rho_e;
-  #endif
+    //const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
+     //                    0.5 * species_densities[4];
+    //species_densities[5] = rho_e;
+  //#endif
 
   /* for primordial_chemistry >= 2 */
-  #if GEARRT_GRACKLE_MODE >= 2
-    species_densities[6] = p->rt_data.tchem.mass_fraction_HM * rho;
-    species_densities[7] = p->rt_data.tchem.mass_fraction_H2I * rho;
-    species_densities[8] = p->rt_data.tchem.mass_fraction_H2II * rho;
+  //#if GEARRT_GRACKLE_MODE >= 2
+    //species_densities[6] = p->rt_data.tchem.mass_fraction_HM * rho;
+    //species_densities[7] = p->rt_data.tchem.mass_fraction_H2I * rho;
+    //species_densities[8] = p->rt_data.tchem.mass_fraction_H2II * rho;
+   
+    //const gr_float rho_e2 = species_densities[1] + 0.25 * species_densities[3] +
+    //                     0.5 * species_densities[4] - species_densities[6] + 0.5 * species_densities[8];
+    //species_densities[5] = rho_e2;
+  //#endif
+  for (enum rt_species species = 0; species < rt_species_count; species++){
+	if (species != 5)
+	{
+		species_densities[species] = p->rt_data.tchem.mass_fraction[species];
+	}
+  }
 
-    const gr_float rho_e2 = species_densities[1] + 0.25 * species_densities[3] +
-                         0.5 * species_densities[4] - species_densities[6] + 0.5 * species_densities[8];
-    species_densities[5] = rho_e2;
+  #if GEARRT_GRACKLE_MODE >= 1
+  const gr_float rho_e = species_densities[rt_species_HII] + 0.25 * species_densities[rt_species_HeII] +
+                         0.5 * species_densities[rt_species_HeIII];
+  species_densities[rt_species_e] = rho_e;
   #endif
+	
+  #if GEARRT_GRACKLE_MODE >= 2
+  const gr_float rho_e2 = species_densities[rt_species_HII] + 0.25 * species_densities[rt_species_HeII] +
+                         0.5 * species_densities[rt_species_HeIII] - species_densities[rt_species_HM] + 0.5 * species_densities[rt_species_H2II];
+  species_densities[rt_species_e] = rho_e2;
+  #endif
+
 }
 
 /**
@@ -183,11 +202,11 @@ rt_tchem_get_gas_temperature(const struct part* restrict p,
   const double kB = phys_const->const_boltzmann_k;
   const double mp = phys_const->const_proton_mass;
 
-  const float XHI = p->rt_data.tchem.mass_fraction_HI;
-  const float XHII = p->rt_data.tchem.mass_fraction_HII;
-  const float XHeI = p->rt_data.tchem.mass_fraction_HeI;
-  const float XHeII = p->rt_data.tchem.mass_fraction_HeII;
-  const float XHeIII = p->rt_data.tchem.mass_fraction_HeIII;
+  const float XHI = p->rt_data.tchem.mass_fraction[rt_species_HI];
+  const float XHII = p->rt_data.tchem.mass_fraction[rt_species_HII];
+  const float XHeI = p->rt_data.tchem.mass_fraction[rt_species_HeI];
+  const float XHeII = p->rt_data.tchem.mass_fraction[rt_species_HeII];
+  const float XHeIII = p->rt_data.tchem.mass_fraction[rt_species_HeIII];
 
   const double mu =
       rt_tchem_get_mean_molecular_weight(XHI, XHII, XHeI, XHeII, XHeIII);

--- a/src/rt/GEAR/rt_unphysical.h
+++ b/src/rt/GEAR/rt_unphysical.h
@@ -72,11 +72,11 @@ __attribute__((always_inline)) INLINE static void rt_check_unphysical_state(
   }
 
   /* Check for too high fluxes */
-  const float flux2 = flux[0] * flux[0] + flux[1] * flux[1] + flux[2] * flux[2];
-  const float flux_norm = sqrtf(flux2);
-  const float flux_max = rt_params.reduced_speed_of_light * *energy_density;
+  const double flux2 = flux[0] * flux[0] + flux[1] * flux[1] + flux[2] * flux[2];
+  const double flux_norm = sqrt(flux2);
+  const double flux_max = rt_params.reduced_speed_of_light * *energy_density;
   if (flux_norm > flux_max) {
-    const float correct = flux_max / flux_norm;
+    const double correct = flux_max / flux_norm;
     flux[0] *= correct;
     flux[1] *= correct;
     flux[2] *= correct;

--- a/src/rt/GEAR/rt_unphysical.h
+++ b/src/rt/GEAR/rt_unphysical.h
@@ -186,44 +186,44 @@ rt_check_unphysical_mass_fractions(struct part* restrict p) {
 
   if (p->conserved.mass <= 0.f || p->rho <= 0.f) {
     /* Deal with unphysical situations and vacuum. */
-    p->rt_data.tchem.mass_fraction_HI = RT_GEAR_TINY_MASS_FRACTION;
-    p->rt_data.tchem.mass_fraction_HII = RT_GEAR_TINY_MASS_FRACTION;
-    p->rt_data.tchem.mass_fraction_HeI = RT_GEAR_TINY_MASS_FRACTION;
-    p->rt_data.tchem.mass_fraction_HeII = RT_GEAR_TINY_MASS_FRACTION;
-    p->rt_data.tchem.mass_fraction_HeIII = RT_GEAR_TINY_MASS_FRACTION;
+    p->rt_data.tchem.mass_fraction[rt_species_HI] = RT_GEAR_TINY_MASS_FRACTION;
+    p->rt_data.tchem.mass_fraction[rt_species_HII] = RT_GEAR_TINY_MASS_FRACTION;
+    p->rt_data.tchem.mass_fraction[rt_species_HeI] = RT_GEAR_TINY_MASS_FRACTION;
+    p->rt_data.tchem.mass_fraction[rt_species_HeII] = RT_GEAR_TINY_MASS_FRACTION;
+    p->rt_data.tchem.mass_fraction[rt_species_HeIII] = RT_GEAR_TINY_MASS_FRACTION;
     return;
   }
 
 #ifdef SWIFT_RT_DEBUG_CHECKS
-  if (p->rt_data.tchem.mass_fraction_HI < -1e4)
+  if (p->rt_data.tchem.mass_fraction[rt_species_HI] < -1e4)
     message("WARNING: Got negative HI mass fraction?");
-  if (p->rt_data.tchem.mass_fraction_HII < -1e4)
+  if (p->rt_data.tchem.mass_fraction[rt_species_HII] < -1e4)
     message("WARNING: Got negative HII mass fraction?");
-  if (p->rt_data.tchem.mass_fraction_HeI < -1e4)
+  if (p->rt_data.tchem.mass_fraction[rt_species_HeI] < -1e4)
     message("WARNING: Got negative HeI mass fraction?");
-  if (p->rt_data.tchem.mass_fraction_HeII < -1e4)
+  if (p->rt_data.tchem.mass_fraction[rt_species_HeII] < -1e4)
     message("WARNING: Got negative HeII mass fraction?");
-  if (p->rt_data.tchem.mass_fraction_HeIII < -1e4)
+  if (p->rt_data.tchem.mass_fraction[rt_species_HeIII] < -1e4)
     message("WARNING: Got negative HeIII mass fraction?");
 #endif
 
   /* TODO: this should be a for loop with mass fractions being enums. */
-  p->rt_data.tchem.mass_fraction_HI =
-      max(p->rt_data.tchem.mass_fraction_HI, RT_GEAR_TINY_MASS_FRACTION);
-  p->rt_data.tchem.mass_fraction_HII =
-      max(p->rt_data.tchem.mass_fraction_HII, RT_GEAR_TINY_MASS_FRACTION);
-  p->rt_data.tchem.mass_fraction_HeI =
-      max(p->rt_data.tchem.mass_fraction_HeI, RT_GEAR_TINY_MASS_FRACTION);
-  p->rt_data.tchem.mass_fraction_HeII =
-      max(p->rt_data.tchem.mass_fraction_HeII, RT_GEAR_TINY_MASS_FRACTION);
-  p->rt_data.tchem.mass_fraction_HeIII =
-      max(p->rt_data.tchem.mass_fraction_HeIII, RT_GEAR_TINY_MASS_FRACTION);
+  p->rt_data.tchem.mass_fraction[rt_species_HI] =
+      max(p->rt_data.tchem.mass_fraction[rt_species_HI], RT_GEAR_TINY_MASS_FRACTION);
+  p->rt_data.tchem.mass_fraction[rt_species_HII] =
+      max(p->rt_data.tchem.mass_fraction[rt_species_HII], RT_GEAR_TINY_MASS_FRACTION);
+  p->rt_data.tchem.mass_fraction[rt_species_HeI] =
+      max(p->rt_data.tchem.mass_fraction[rt_species_HeI], RT_GEAR_TINY_MASS_FRACTION);
+  p->rt_data.tchem.mass_fraction[rt_species_HeII] =
+      max(p->rt_data.tchem.mass_fraction[rt_species_HeII], RT_GEAR_TINY_MASS_FRACTION);
+  p->rt_data.tchem.mass_fraction[rt_species_HeIII] =
+      max(p->rt_data.tchem.mass_fraction[rt_species_HeIII], RT_GEAR_TINY_MASS_FRACTION);
 
-  const float XHI = p->rt_data.tchem.mass_fraction_HI;
-  const float XHII = p->rt_data.tchem.mass_fraction_HII;
-  const float XHeI = p->rt_data.tchem.mass_fraction_HeI;
-  const float XHeII = p->rt_data.tchem.mass_fraction_HeII;
-  const float XHeIII = p->rt_data.tchem.mass_fraction_HeIII;
+  const float XHI = p->rt_data.tchem.mass_fraction[rt_species_HI];
+  const float XHII = p->rt_data.tchem.mass_fraction[rt_species_HII];
+  const float XHeI = p->rt_data.tchem.mass_fraction[rt_species_HeI];
+  const float XHeII = p->rt_data.tchem.mass_fraction[rt_species_HeII];
+  const float XHeIII = p->rt_data.tchem.mass_fraction[rt_species_HeIII];
 
   const float Xtot = XHI + XHII + XHeI + XHeII + XHeIII;
 

--- a/src/rt/GEAR/rt_unphysical.h
+++ b/src/rt/GEAR/rt_unphysical.h
@@ -72,7 +72,8 @@ __attribute__((always_inline)) INLINE static void rt_check_unphysical_state(
   }
 
   /* Check for too high fluxes */
-  const double flux2 = flux[0] * flux[0] + flux[1] * flux[1] + flux[2] * flux[2];
+  const double flux2 =
+      flux[0] * flux[0] + flux[1] * flux[1] + flux[2] * flux[2];
   const double flux_norm = sqrt(flux2);
   const double flux_max = rt_params.reduced_speed_of_light * *energy_density;
   if (flux_norm > flux_max) {

--- a/tools/convert_snapshot_to_ICs.py
+++ b/tools/convert_snapshot_to_ICs.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+"""
+Script to convert the NIFTY ICs to those that are compatible with SWIFT.
+Note that this leaves h-factors as-is to be fixed in-place by SWIFT.
+
+You will need:
+
+    + swiftsimio
+"""
+
+from swiftsimio import Writer, load
+import numpy as np
+import unyt
+import os
+
+# Which file to read
+#  filename = "./eagle_0000.hdf5"
+filename = "output_0001.hdf5"
+# What to call the output IC file
+output_filename = "ICs.hdf5"
+
+
+# -----------------------------------------------------------------------
+# -----------------------------------------------------------------------
+
+
+if not os.path.exists(filename):
+    raise FileNotFoundError(filename)
+
+warning = """
+SWIFT snapshots are not written in a way that should be used as initial
+conditions. By using this script, you're trying to do exactly that. Are
+you sure you know what you're doing? [y/n]
+"""
+
+answer = input(warning)
+if not answer.startswith("y") or answer.startswith("Y"):
+    print("Quitting.")
+    quit()
+
+# Load data from snapshot.
+
+snap = load(filename)
+
+# Get units and create unyt.unitsystem.
+length = snap.units.length
+mass = snap.units.mass
+time = snap.units.time
+temperature = snap.units.temperature
+
+my_units = unyt.UnitSystem("copiedFromSnapshot", length, mass, time, temperature)
+
+
+# Store additional info about the snapshot in the ICs. Can't hurt to have the data lying around.
+extra_header = {}
+
+if snap.metadata.cosmology is not None:
+
+    #  Accessing data through metadata.cosmology_raw works on older snapshots as
+    #  well, so let's do it this way.
+
+    extra_header[
+        "snapshot cosmology Critical density [internal_units]"
+    ] = snap.metadata.cosmology_raw["Critical density [internal units]"]
+    extra_header["snapshot cosmology H [internal units]"] = snap.metadata.cosmology_raw[
+        "H [internal units]"
+    ]
+    extra_header[
+        "snapshot cosmology H0 [internal units]"
+    ] = snap.metadata.cosmology_raw["H0 [internal units]"]
+    extra_header[
+        "snapshot cosmology Hubble time [internal units]"
+    ] = snap.metadata.cosmology_raw["Hubble time [internal units]"]
+    extra_header[
+        "snapshot cosmology Lookback time [internal units]"
+    ] = snap.metadata.cosmology_raw["Lookback time [internal units]"]
+    extra_header["snapshot cosmology N_eff"] = snap.metadata.cosmology_raw["N_eff"]
+    extra_header["snapshot cosmology N_nu"] = snap.metadata.cosmology_raw["N_nu"]
+    extra_header["snapshot cosmology N_ur"] = snap.metadata.cosmology_raw["N_ur"]
+    extra_header["snapshot cosmology Omega_b"] = snap.metadata.cosmology_raw["Omega_b"]
+    extra_header["snapshot cosmology Omega_cdm"] = snap.metadata.cosmology_raw[
+        "Omega_cdm"
+    ]
+    extra_header["snapshot cosmology Omega_g"] = snap.metadata.cosmology_raw["Omega_g"]
+    extra_header["snapshot cosmology Omega_k"] = snap.metadata.cosmology_raw["Omega_k"]
+    extra_header["snapshot cosmology Omega_lambda"] = snap.metadata.cosmology_raw[
+        "Omega_lambda"
+    ]
+    extra_header["snapshot cosmology Omega_m"] = snap.metadata.cosmology_raw["Omega_m"]
+    extra_header["snapshot cosmology Omega_nu"] = snap.metadata.cosmology_raw[
+        "Omega_nu"
+    ]
+    extra_header["snapshot cosmology Omega_nu_0"] = snap.metadata.cosmology_raw[
+        "Omega_nu_0"
+    ]
+    extra_header["snapshot cosmology Omega_r"] = snap.metadata.cosmology_raw["Omega_r"]
+    extra_header["snapshot cosmology Omega_ur"] = snap.metadata.cosmology_raw[
+        "Omega_ur"
+    ]
+    extra_header["snapshot cosmology T_CMB_0 [K]"] = snap.metadata.cosmology_raw[
+        "T_CMB_0 [K]"
+    ]
+    extra_header[
+        "snapshot cosmology T_CMB_0 [internal_units]"
+    ] = snap.metadata.cosmology_raw["T_CMB_0 [internal units]"]
+    extra_header["snapshot cosmology T_nu_0 [eV]"] = snap.metadata.cosmology_raw[
+        "T_nu_0 [eV]"
+    ]
+    extra_header[
+        "snapshot cosmology T_nu_0 [internal_units]"
+    ] = snap.metadata.cosmology_raw["T_nu_0 [internal units]"]
+    extra_header["snapshot cosmology h"] = snap.metadata.cosmology_raw["h"]
+    extra_header["snapshot cosmology w"] = snap.metadata.cosmology_raw["w"]
+    extra_header["snapshot cosmology w_0"] = snap.metadata.cosmology_raw["w_0"]
+    extra_header["snapshot cosmology w_a"] = snap.metadata.cosmology_raw["w_a"]
+
+else:
+    print("Found no cosmology metadata in snapshot. Continuing without.")
+
+
+extra_header["snapshot a"] = snap.metadata.a
+extra_header["snapshot date"] = snap.metadata.snapshot_date
+extra_header["snapshot dimension"] = snap.metadata.dimension
+extra_header["snapshot filename"] = snap.metadata.filename
+extra_header["snapshot gas gamma"] = snap.metadata.gas_gamma
+extra_header["snapshot gravity scheme"] = snap.metadata.gravity_scheme
+extra_header["snapshot header"] = snap.metadata.header
+extra_header["snapshot hydro info"] = snap.metadata.hydro_info
+extra_header["snapshot hydro scheme"] = snap.metadata.hydro_scheme
+extra_header["snapshot initial mass table"] = snap.metadata.initial_mass_table
+extra_header["snapshot library info"] = snap.metadata.library_info
+extra_header["snapshot mass table"] = snap.metadata.mass_table
+extra_header["snapshot redshift"] = snap.metadata.redshift
+extra_header["snapshot run name"] = snap.metadata.run_name
+extra_header["snapshot scale_factor"] = snap.metadata.scale_factor
+extra_header["snapshot subgrid scheme"] = snap.metadata.subgrid_scheme
+extra_header["snapshot stars properties"] = snap.metadata.stars_properties
+extra_header["snapshot stars scheme"] = snap.metadata.stars_scheme
+extra_header["snapshot system name"] = snap.metadata.system_name
+extra_header["snapshot time"] = snap.metadata.time
+
+
+# Initialize the Writer
+writer = Writer(
+    unit_system=my_units,
+    box_size=snap.metadata.boxsize,
+    dimension=snap.metadata.dimension,
+    compress=True,
+    extra_header=extra_header,
+    scale_factor=snap.metadata.scale_factor,
+)
+
+#  /PartType0/ - Gas
+#  /PartType1/ - Dark Matter
+#  /PartType2/ - Background Dark Matter
+#  /PartType3/ - Sinks
+#  /PartType4/ - Stars
+#  /PartType5/ - Black Holes
+#  /PartType6/ - Neutrino Dark Matter
+
+if snap.metadata.has_type[0]:
+    # Get and write gas
+    print("Adding gas data to ICs.")
+    writer.gas.coordinates = snap.gas.coordinates
+    writer.gas.velocities = snap.gas.velocities
+    writer.gas.masses = snap.gas.masses
+    writer.gas.internal_energy = snap.gas.internal_energies
+    writer.gas.smoothing_length = snap.gas.smoothing_lengths
+    writer.gas.particle_ids = snap.gas.particle_ids
+else:
+    print("Found no gas data in snapshot. Continuing without.")
+
+if snap.metadata.has_type[1]:
+    # Get and write dark matter
+    print("Adding dark matter data to ICs.")
+    writer.dark_matter.coordinates = snap.dark_matter.coordinates
+    writer.dark_matter.velocities = snap.dark_matter.velocities
+    writer.dark_matter.masses = snap.dark_matter.masses
+    writer.dark_matter.particle_ids = snap.dark_matter.particle_ids
+else:
+    print("Found no dark matter data in snapshot. Continuing without.")
+
+if snap.metadata.has_type[3]:
+    # Get and write sinks
+    print("Adding sinks data to ICs.")
+    writer.sinks.coordinates = snap.sinks.coordinates
+    writer.sinks.velocities = snap.sinks.velocities
+    writer.sinks.masses = snap.sinks.masses
+    writer.sinks.particle_ids = snap.sinks.particle_ids
+else:
+    print("Found no sinks data in snapshot. Continuing without.")
+
+if snap.metadata.has_type[4]:
+    # Get and write stars
+    print("Adding stars data to ICs.")
+    writer.stars.coordinates = snap.stars.coordinates
+    writer.stars.velocities = snap.stars.velocities
+    writer.stars.masses = snap.stars.masses
+    writer.stars.smoothing_length = snap.stars.smoothing_lengths
+    writer.stars.particle_ids = snap.stars.particle_ids
+else:
+    print("Found no star data in snapshot. Continuing without.")
+
+
+if snap.metadata.has_type[5]:
+    # Get and write black holes
+    print("Adding black holes data to ICs.")
+    writer.black_holes.coordinates = snap.black_holes.coordinates
+    writer.black_holes.velocities = snap.black_holes.velocities
+    writer.black_holes.masses = snap.black_holes.masses
+    writer.black_holes.particle_ids = snap.black_holes.particle_ids
+    writer.black_holes.smoothing_length = snap.black_holes.smoothing_lengths
+else:
+    print("Found no black hole data in snapshot. Continuing without.")
+
+
+if snap.metadata.has_type[6]:
+    # Get and write neutrinos
+    # TODO
+    raise NotImplementedError("Can't write neutrino ICs yet.")
+
+
+# Finally, write everything.
+writer.write(output_filename)


### PR DESCRIPTION
- allocate memory for three extra species
- define a macro RT_N_SPECIES for counting the number of species in each mode and using in
species_densities[RT_N_SPECIES]
- add the initial condition for these species to be zero

- in do_thermochemistry function, add three extra species and also update the electron number density calculation